### PR TITLE
added animation in feed likes:

### DIFF
--- a/src/hooks/usePulseAnimation.ts
+++ b/src/hooks/usePulseAnimation.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { Animated } from 'react-native';
+
+export function usePulseAnimation(triggerKey: string | number) {
+  const scale = useRef(new Animated.Value(1)).current;
+  const lastTriggerRef = useRef<string | number | null>(null);
+
+  useEffect(() => {
+    if (lastTriggerRef.current === triggerKey) {
+      return;
+    }
+    lastTriggerRef.current = triggerKey;
+    Animated.sequence([
+      Animated.timing(scale, {
+        toValue: 1.15,
+        duration: 110,
+        useNativeDriver: true,
+      }),
+      Animated.timing(scale, {
+        toValue: 1,
+        duration: 90,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [scale, triggerKey]);
+
+  return {
+    animatedStyle: {
+      transform: [{ scale }],
+    },
+  };
+}


### PR DESCRIPTION
- [x] Added a reusable pulse hook (usePulseAnimation) and wired it into the Feed like button.

- [x] FeedPostCard now pulses the like text/icon when you newly like a post (or when like state flips to liked via sync); tracks previous liked state and a pulseKey for controlled triggers.